### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ from dagster import (
     AssetExecutionContext,
     Definitions,
 )
-from dagster_sqlmesh import sqlmesh_asset, SQLMeshContextConfig, SQLMeshResource
+from dagster_sqlmesh import sqlmesh_assets, SQLMeshContextConfig, SQLMeshResource
 
 sqlmesh_config = SQLMeshContextConfig(path="/home/foo/sqlmesh_project", gateway="name-of-your-gateway")
 


### PR DESCRIPTION
Should import `sqlmesh_assets` instead of `sqlmesh_asset`.
Prior to this patch, the example fails with this error:

    cannot import name 'sqlmesh_asset' from 'dagster_sqlmesh'