### PR TITLE
feat: enable subsetting behind flag

### DIFF
--- a/dagster_sqlmesh/asset.py
+++ b/dagster_sqlmesh/asset.py
@@ -25,6 +25,8 @@ def sqlmesh_assets(
     op_tags: t.Optional[t.Mapping[str, t.Any]] = None,
     required_resource_keys: t.Optional[t.Set[str]] = None,
     retry_policy: t.Optional[RetryPolicy] = None,
+    # For now we don't set this by default
+    enabled_subsetting: bool = False,
 ):
     controller = DagsterSQLMeshController.setup_with_config(config)
     if not dagster_sqlmesh_translator:
@@ -39,5 +41,6 @@ def sqlmesh_assets(
         op_tags=op_tags,
         compute_kind=compute_kind,
         retry_policy=retry_policy,
+        can_subset=enabled_subsetting,
         required_resource_keys=required_resource_keys,
     )

--- a/dagster_sqlmesh/console.py
+++ b/dagster_sqlmesh/console.py
@@ -335,6 +335,7 @@ class EventConsole(Console):
         self._handlers: Dict[str, ConsoleEventHandler] = {}
         self.logger = log_override or logger
         self.id = str(uuid.uuid4())
+        self.logger.debug(f"EventConsole[{self.id}]: created")
         self.categorizer = None
 
     def add_snapshot_categorizer(self, categorizer: SnapshotCategorizer):
@@ -459,7 +460,9 @@ class EventConsole(Console):
         no_diff: bool = False,
         no_prompts: bool = False,
     ) -> None:
+        self.logger.debug("building plan created")
         plan = plan_builder.build()
+        self.logger.debug(f"plan created: {plan}")
 
         for snapshot in plan.uncategorized:
             if self.categorizer:

--- a/dagster_sqlmesh/events.py
+++ b/dagster_sqlmesh/events.py
@@ -73,7 +73,7 @@ class ConsoleGenerator:
         while thread.is_alive() or not self._queue.empty():
             try:
                 # Get arguments from the queue with a timeout
-                args = self._queue.get(timeout=0.1)
+                args = self._queue.get(timeout=0.5)
                 yield args
             except queue.Empty:
                 continue

--- a/sample/dagster_project/definitions.py
+++ b/sample/dagster_project/definitions.py
@@ -51,7 +51,7 @@ def test_source() -> pl.DataFrame:
     )
 
 
-@sqlmesh_assets(environment="dev", config=sqlmesh_config)
+@sqlmesh_assets(environment="dev", config=sqlmesh_config, enabled_subsetting=True)
 def sqlmesh_project(context: AssetExecutionContext, sqlmesh: SQLMeshResource):
     yield from sqlmesh.run(context)
 


### PR DESCRIPTION
Enables subsetting sqlmesh resources. I tested this a bit but it's likely best to keep it behind the current flag for now. That being said, normal run and subset run now both explicitly pass the `select_models` and `backfill_models` options