### PR TITLE
feat: introduce dagster sqlmesh cache

### DIFF
--- a/dagster_sqlmesh/__init__.py
+++ b/dagster_sqlmesh/__init__.py
@@ -4,3 +4,4 @@ from .asset import *
 from .config import *
 from .controller import *
 from .resource import *
+from .translator import *

--- a/dagster_sqlmesh/__init__.py
+++ b/dagster_sqlmesh/__init__.py
@@ -2,4 +2,5 @@
 
 from .asset import *
 from .config import *
+from .controller import *
 from .resource import *

--- a/dagster_sqlmesh/asset.py
+++ b/dagster_sqlmesh/asset.py
@@ -15,39 +15,56 @@ from dagster_sqlmesh.types import SQLMeshMultiAssetOptions
 
 logger = logging.getLogger(__name__)
 
-class MultiAssetFactory(t.Protocol):
-    def __call__(self, 
-        multi_asset_options: SQLMeshMultiAssetOptions,
-        compute_kind: str,
-        name: str | None = None,
-        op_tags: t.Mapping[str, t.Any] | None = None,
-        required_resource_keys: set[str] | None = None,
-        retry_policy: RetryPolicy | None = None,
-        enabled_subsetting: bool = False,
-    ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
-        """Factory function to create a multi asset definition from SQLMeshMultiAssetOptions."""
-        ...
+def sqlmesh_to_multi_asset_options(
+    *,
+    environment: str,
+    config: SQLMeshContextConfig,
+    context_factory: ContextFactory[ContextCls] = lambda **kwargs: Context(**kwargs),
+    dagster_sqlmesh_translator: SQLMeshDagsterTranslator | None = None,
+) -> SQLMeshMultiAssetOptions:
+    """Converts sqlmesh project into a SQLMeshMultiAssetOptions object which is
+    an intermediate representation of the SQLMesh project that can be used to
+    create a dagster multi_asset definition."""
+    controller = DagsterSQLMeshController.setup_with_config(
+        config=config, context_factory=context_factory
+    )
+    if not dagster_sqlmesh_translator:
+        dagster_sqlmesh_translator = SQLMeshDagsterTranslator()
 
-def _multi_asset_factory(
-    multi_asset_options: SQLMeshMultiAssetOptions,
-    compute_kind: str,
+    conversion = controller.to_asset_outs(
+        environment,
+        translator=dagster_sqlmesh_translator,
+    )
+    return conversion
+
+def sqlmesh_asset_from_multi_asset_options(
+    *,
+    sqlmesh_multi_asset_options: SQLMeshMultiAssetOptions,
     name: str | None = None,
+    compute_kind: str = "sqlmesh",
     op_tags: t.Mapping[str, t.Any] | None = None,
     required_resource_keys: set[str] | None = None,
     retry_policy: RetryPolicy | None = None,
     enabled_subsetting: bool = False,
 ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
-    """Factory function to create a multi asset definition from SQLMeshMultiAssetOptions."""
+    """Creates a dagster multi_asset definition from a SQLMeshMultiAssetOptions object."""
+    kwargs: dict[str, t.Any] = {}
+    if enabled_subsetting:
+        kwargs["can_subset"] = True
+
+    #asset_deps = sqlmesh_multi_asset_options.to_asset_deps()   
+    #print("Asset deps boop:", asset_deps)  # Debugging line
+
     return multi_asset(
+        outs=sqlmesh_multi_asset_options.to_asset_outs(),
+        deps=sqlmesh_multi_asset_options.to_asset_deps(),
+        internal_asset_deps=sqlmesh_multi_asset_options.to_internal_asset_deps(),
         name=name,
-        outs=multi_asset_options.to_asset_outs(),
-        deps=multi_asset_options.to_asset_deps(),
-        internal_asset_deps=multi_asset_options.to_internal_asset_deps(),
-        op_tags=op_tags,
         compute_kind=compute_kind,
-        retry_policy=retry_policy,
-        can_subset=enabled_subsetting,
+        op_tags=op_tags,
         required_resource_keys=required_resource_keys,
+        retry_policy=retry_policy,
+        **kwargs,
     )
 
 # Define a SQLMesh Asset
@@ -64,21 +81,16 @@ def sqlmesh_assets(
     retry_policy: RetryPolicy | None = None,
     # For now we don't set this by default
     enabled_subsetting: bool = False,
-    multi_asset_factory: MultiAssetFactory = _multi_asset_factory,
 ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
-    controller = DagsterSQLMeshController.setup_with_config(
-        config=config, context_factory=context_factory
-    )
-    if not dagster_sqlmesh_translator:
-        dagster_sqlmesh_translator = SQLMeshDagsterTranslator()
-
-    conversion = controller.to_asset_outs(
-        environment,
-        translator=dagster_sqlmesh_translator,
+    conversion = sqlmesh_to_multi_asset_options(
+        environment=environment,
+        config=config,
+        context_factory=context_factory,
+        dagster_sqlmesh_translator=dagster_sqlmesh_translator,
     )
     
-    return multi_asset_factory(
-        multi_asset_options=conversion,
+    return sqlmesh_asset_from_multi_asset_options(
+        sqlmesh_multi_asset_options=conversion,
         name=name,
         compute_kind=compute_kind,
         op_tags=op_tags,

--- a/dagster_sqlmesh/asset.py
+++ b/dagster_sqlmesh/asset.py
@@ -10,6 +10,7 @@ from dagster_sqlmesh.controller import (
     ContextFactory,
     DagsterSQLMeshController,
 )
+from dagster_sqlmesh.controller.dagster import DagsterSQLMeshCacheOptions
 from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
 
 logger = logging.getLogger(__name__)
@@ -29,11 +30,19 @@ def sqlmesh_assets(
     retry_policy: RetryPolicy | None = None,
     # For now we don't set this by default
     enabled_subsetting: bool = False,
+    cache_options: DagsterSQLMeshCacheOptions | None = None,
 ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
-    controller = DagsterSQLMeshController.setup_with_config(config=config, context_factory=context_factory)
+    controller = DagsterSQLMeshController.setup_with_config(
+        config=config, context_factory=context_factory
+    )
     if not dagster_sqlmesh_translator:
         dagster_sqlmesh_translator = SQLMeshDagsterTranslator()
-    conversion = controller.to_asset_outs(environment, translator=dagster_sqlmesh_translator)
+
+    conversion = controller.to_asset_outs(
+        environment,
+        translator=dagster_sqlmesh_translator,
+        cache_options=cache_options,
+    )
 
     return multi_asset(
         name=name,

--- a/dagster_sqlmesh/asset.py
+++ b/dagster_sqlmesh/asset.py
@@ -10,11 +10,45 @@ from dagster_sqlmesh.controller import (
     ContextFactory,
     DagsterSQLMeshController,
 )
-from dagster_sqlmesh.controller.dagster import DagsterSQLMeshCacheOptions
 from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
+from dagster_sqlmesh.types import SQLMeshMultiAssetOptions
 
 logger = logging.getLogger(__name__)
 
+class MultiAssetFactory(t.Protocol):
+    def __call__(self, 
+        multi_asset_options: SQLMeshMultiAssetOptions,
+        compute_kind: str,
+        name: str | None = None,
+        op_tags: t.Mapping[str, t.Any] | None = None,
+        required_resource_keys: set[str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        enabled_subsetting: bool = False,
+    ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
+        """Factory function to create a multi asset definition from SQLMeshMultiAssetOptions."""
+        ...
+
+def _multi_asset_factory(
+    multi_asset_options: SQLMeshMultiAssetOptions,
+    compute_kind: str,
+    name: str | None = None,
+    op_tags: t.Mapping[str, t.Any] | None = None,
+    required_resource_keys: set[str] | None = None,
+    retry_policy: RetryPolicy | None = None,
+    enabled_subsetting: bool = False,
+) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
+    """Factory function to create a multi asset definition from SQLMeshMultiAssetOptions."""
+    return multi_asset(
+        name=name,
+        outs=multi_asset_options.to_asset_outs(),
+        deps=multi_asset_options.to_asset_deps(),
+        internal_asset_deps=multi_asset_options.to_internal_asset_deps(),
+        op_tags=op_tags,
+        compute_kind=compute_kind,
+        retry_policy=retry_policy,
+        can_subset=enabled_subsetting,
+        required_resource_keys=required_resource_keys,
+    )
 
 # Define a SQLMesh Asset
 def sqlmesh_assets(
@@ -30,7 +64,7 @@ def sqlmesh_assets(
     retry_policy: RetryPolicy | None = None,
     # For now we don't set this by default
     enabled_subsetting: bool = False,
-    cache_options: DagsterSQLMeshCacheOptions | None = None,
+    multi_asset_factory: MultiAssetFactory = _multi_asset_factory,
 ) -> t.Callable[[t.Callable[..., t.Any]], AssetsDefinition]:
     controller = DagsterSQLMeshController.setup_with_config(
         config=config, context_factory=context_factory
@@ -41,17 +75,14 @@ def sqlmesh_assets(
     conversion = controller.to_asset_outs(
         environment,
         translator=dagster_sqlmesh_translator,
-        cache_options=cache_options,
     )
-
-    return multi_asset(
+    
+    return multi_asset_factory(
+        multi_asset_options=conversion,
         name=name,
-        outs=conversion.outs,
-        deps=conversion.deps,
-        internal_asset_deps=conversion.internal_asset_deps,
-        op_tags=op_tags,
         compute_kind=compute_kind,
-        retry_policy=retry_policy,
-        can_subset=enabled_subsetting,
+        op_tags=op_tags,
         required_resource_keys=required_resource_keys,
+        retry_policy=retry_policy,
+        enabled_subsetting=enabled_subsetting,
     )

--- a/dagster_sqlmesh/controller/__init__.py
+++ b/dagster_sqlmesh/controller/__init__.py
@@ -8,4 +8,4 @@ from .base import (
     SQLMeshController,
     SQLMeshInstance,
 )
-from .dagster import DagsterSQLMeshCacheOptions, DagsterSQLMeshController
+from .dagster import DagsterSQLMeshController

--- a/dagster_sqlmesh/controller/__init__.py
+++ b/dagster_sqlmesh/controller/__init__.py
@@ -8,4 +8,4 @@ from .base import (
     SQLMeshController,
     SQLMeshInstance,
 )
-from .dagster import DagsterSQLMeshController
+from .dagster import DagsterSQLMeshCacheOptions, DagsterSQLMeshController

--- a/dagster_sqlmesh/controller/dagster.py
+++ b/dagster_sqlmesh/controller/dagster.py
@@ -1,11 +1,20 @@
 # pyright: reportPrivateImportUsage=false
 import logging
+import time
+import typing as t
+from dataclasses import dataclass
 from inspect import signature
+from pathlib import Path
 
 from dagster import AssetDep, AssetKey, AssetOut
 from dagster._core.definitions.asset_dep import CoercibleToAssetDep
+from pydantic import BaseModel, Field, model_validator
 
-from dagster_sqlmesh.controller.base import ContextCls, SQLMeshController
+from dagster_sqlmesh.controller.base import (
+    ContextCls,
+    SQLMeshController,
+    SQLMeshInstance,
+)
 from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
 from dagster_sqlmesh.types import SQLMeshModelDep, SQLMeshMultiAssetOptions
 from dagster_sqlmesh.utils import get_asset_key_str
@@ -13,51 +22,354 @@ from dagster_sqlmesh.utils import get_asset_key_str
 logger = logging.getLogger(__name__)
 
 
+class CachedMetadata(BaseModel):
+    """Metadata for the cache file"""
+
+    type: t.Literal["metadata"] = "metadata"
+
+    creation_ts: int
+    environment: str
+
+
+class CachedAssetOut(BaseModel):
+    type: t.Literal["asset_out"] = "asset_out"
+
+    model_key: str
+    asset_key: str
+    tags: t.Mapping[str, str]
+    is_required: bool
+    group_name: str
+    kinds: set[str] | None
+
+    def to_asset_out(self) -> AssetOut:
+        """Convert to a Dagster AssetOut object"""
+        if "kinds" in signature(AssetOut).parameters:
+            return AssetOut(
+                key=AssetKey.from_user_string(self.asset_key),
+                tags=self.tags,
+                is_required=self.is_required,
+                group_name=self.group_name,
+                kinds=self.kinds,
+            )
+        return AssetOut(
+            key=AssetKey.from_user_string(self.asset_key),
+            tags=self.tags,
+            is_required=self.is_required,
+            group_name=self.group_name,
+        )
+
+    @classmethod
+    def from_asset_out(cls, model_key: str, asset_out: AssetOut) -> "CachedAssetOut":
+        """Create from a Dagster AssetOut object"""
+        assert asset_out.key is not None, "AssetOut key must not be None"
+
+        return cls(
+            model_key=model_key,
+            asset_key=asset_out.key.to_user_string(),
+            tags=asset_out.tags or {},
+            is_required=asset_out.is_required,
+            group_name=asset_out.group_name or "",
+            kinds=asset_out.kinds,
+        )
+
+
+class CachedInternalAssetDeps(BaseModel):
+    type: t.Literal["internal_asset_dep"] = "internal_asset_dep"
+
+    internal_asset_deps: dict[str, set[str]]
+
+    def to_internal_asset_deps(self) -> dict[str, set[AssetKey]]:
+        """Convert to a Dagster internal asset dependencies dictionary"""
+        return {
+            k: {AssetKey.from_user_string(dep) for dep in v}
+            for k, v in self.internal_asset_deps.items()
+        }
+
+    @classmethod
+    def from_internal_asset_deps(
+        cls, internal_asset_deps: dict[str, set[AssetKey]]
+    ) -> "CachedInternalAssetDeps":
+        """Create from a Dagster internal asset dependencies dictionary"""
+        return cls(
+            internal_asset_deps={
+                k: {dep.to_user_string() for dep in v}
+                for k, v in internal_asset_deps.items()
+            }
+        )
+
+
+class CachedDeps(BaseModel):
+    type: t.Literal["deps"] = "deps"
+
+    deps: list[dict[str, str]]
+
+    def to_deps(self) -> list[CoercibleToAssetDep]:
+        """Convert to a Dagster deps list"""
+        return [AssetDep(AssetKey.from_user_string(dep["key"])) for dep in self.deps]
+
+    @classmethod
+    def from_deps(cls, deps: list[AssetDep]) -> "CachedDeps":
+        """Create from a Dagster deps list"""
+        return cls(deps=[{"key": dep.asset_key.to_user_string()} for dep in deps])
+
+
+CacheEntryPayload = (
+    CachedAssetOut | CachedInternalAssetDeps | CachedDeps | CachedMetadata
+)
+
+
+class CacheEntry(BaseModel):
+    payload: CacheEntryPayload = Field(discriminator="type")
+
+
+class DagsterSQLMeshCacheOptions(BaseModel):
+    """SQLMesh context cache for Dagster"""
+
+    enabled: bool
+    cache_dir: str = ""
+    cache_filename: str = "dagster_sqlmesh_cache.jsonl"
+    enable_ttl: bool = True
+    ttl_seconds: int = 60 * 5 # Defaults to 5 minutes
+
+    @model_validator(mode="after")
+    def validate_cache_dir(self):
+        """Ensure the cache directory is set if caching is enabled"""
+        if not self.enabled:
+            return self
+
+        if not self.cache_dir:
+            raise ValueError("cache_dir must be set")
+        return self
+
+
+    def cache_path(self, environment: str) -> str:
+        """Returns the full path to the cache file"""
+        return f"{self.cache_env_dir(environment)}/{self.cache_filename}"
+
+    def cache_env_dir(self, environment: str) -> str:
+        """Returns the directory for the cache file"""
+        return f"{self.cache_dir}/{environment}"
+
+    def asset_streamer(self, environment: str) -> "DagsterSQLMeshCache":
+        """Returns a cache streamer for the given environment"""
+        return DagsterSQLMeshCache(environment=environment, options=self)
+
+
+class CacheableAssetStreamer(t.Protocol):
+    """Protocol for streaming SQLMesh assets from a cache"""
+
+    def stream_assets(self) -> t.Iterator[CacheEntry]:
+        """Stream the cache file if it exists and is valid"""
+        ...
+
+class CacheableAssetCacheWriter(t.Protocol):
+    """Protocol for consuming SQLMesh assets from a cache"""
+
+    def append_to_cache(self, data: CacheEntry) -> None:
+        """Write data to the cache file"""
+        ...
+
+    def start_cache(self) -> None:
+        """Clear the cache to prepare for writing"""
+        ...
+
+class DummyCacheableAssetWriter(CacheableAssetCacheWriter):
+    """A dummy cache writer that does nothing"""
+
+    def append_to_cache(self, data: CacheEntry) -> None:
+        """Does nothing"""
+        pass
+
+    def start_cache(self) -> None:
+        """Does nothing"""
+        pass
+
+@dataclass(kw_only=True)
+class DagsterSQLMeshCache:
+    environment: str
+    options: DagsterSQLMeshCacheOptions
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if the cache file is valid based on the TTL"""
+        try:
+            iterator = self.stream_assets()
+            metadata = next(iterator)  # Get the first entry which should be metadata
+            assert isinstance(
+                metadata.payload, CachedMetadata
+            ), "First entry must be CachedMetadata"
+            if not self.options.enable_ttl:
+                return True
+            if metadata.payload.creation_ts + self.options.ttl_seconds < int(
+                time.time()
+            ):
+                return False
+        except FileNotFoundError:
+            return False
+        except Exception as e:
+            logger.error(f"Error reading cache file: {e}")
+            return False
+        return False
+
+    @property
+    def cache_path(self) -> str:
+        """Returns the cache file path"""
+        return self.options.cache_path(self.environment)
+
+    def stream_assets(self) -> t.Iterator[CacheEntry]:
+        """Stream the cache file if it exists and is valid"""
+        try:
+            with open(self.cache_path) as f:
+                for line in f:
+                    entry = CacheEntry.model_validate_json(line)
+                    yield entry
+        except FileNotFoundError:
+            logger.warning(f"Cache file {self.cache_path} not found.")
+        except Exception as e:
+            logger.error(f"Error reading cache file {self.cache_path}: {e}")
+
+    def start_cache(self) -> None:
+        """Clear the cache to prepare for writing"""
+        # Ensure the cache directory exists
+        Path(self.options.cache_env_dir(self.environment)).mkdir(
+            parents=True, exist_ok=True
+        )
+        # Clear the cache file and write the initial metadata
+        metadata = CachedMetadata(
+            creation_ts=int(time.time()),
+            environment=self.environment,
+        )
+        entry = CacheEntry(payload=metadata)
+        with open(self.cache_path, "w") as f:
+            f.write(entry.model_dump_json())
+            f.write("\n")
+
+    def append_to_cache(self, data: CacheEntry) -> None:
+        """Append data to the cache file"""
+
+        with open(self.cache_path, "a") as f:
+            f.write(data.model_dump_json())
+            f.write("\n")
+
+
+@dataclass(kw_only=True)
+class SQLMeshInstanceAssetStreamer:
+    instance: SQLMeshInstance
+    translator: SQLMeshDagsterTranslator
+
+    def stream_assets(self) -> t.Iterator[CacheEntry]:
+        """Stream the assets from the SQLMesh instance"""
+        instance = self.instance
+        translator = self.translator
+
+        context = self.instance.context
+        internal_asset_deps_map: dict[str, set[AssetKey]] = {}
+        deps_map: dict[str, AssetDep] = {}
+
+        for model, deps in instance.non_external_models_dag():
+            asset_key = translator.get_asset_key(context=context, fqn=model.fqn)
+            model_deps = [
+                SQLMeshModelDep(fqn=dep, model=context.get_model(dep)) for dep in deps
+            ]
+            internal_asset_deps: set[AssetKey] = set()
+            asset_tags = translator.get_tags(context, model)
+
+            for dep in model_deps:
+                if dep.model:
+                    internal_asset_deps.add(
+                        translator.get_asset_key(context, dep.model.fqn)
+                    )
+                else:
+                    table = get_asset_key_str(dep.fqn)
+                    key = translator.get_asset_key(context, dep.fqn)
+                    internal_asset_deps.add(key)
+                    # create an external dep
+                    deps_map[table] = AssetDep(key)
+            model_key = get_asset_key_str(model.fqn)
+            # If current Dagster supports "kinds", add labels for Dagster UI
+            if "kinds" in signature(AssetOut).parameters:
+                yield CacheEntry(payload=CachedAssetOut(
+                    model_key=model_key,
+                    asset_key=asset_key.to_user_string(),
+                    tags=asset_tags,
+                    is_required=False,
+                    group_name=translator.get_group_name(context, model),
+                    kinds={
+                        "sqlmesh",
+                        translator._get_context_dialect(context).lower(),
+                    },
+                ))
+            internal_asset_deps_map[model_key] = internal_asset_deps
+
+        yield CacheEntry(
+            payload=CachedInternalAssetDeps.from_internal_asset_deps(
+                internal_asset_deps=internal_asset_deps_map
+            )
+        )
+
+        deps = list(deps_map.values())
+
+        yield CacheEntry(payload=CachedDeps.from_deps(deps=deps))
+
+
 class DagsterSQLMeshController(SQLMeshController[ContextCls]):
     """An extension of the sqlmesh controller specifically for dagster use"""
 
-    def to_asset_outs(
-        self, environment: str, translator: SQLMeshDagsterTranslator,
+    def to_asset_outs_from_streamer(
+        self,
+        streamer: CacheableAssetStreamer,
+        cache_writer: CacheableAssetCacheWriter,
     ) -> SQLMeshMultiAssetOptions:
+        """Read the cache file and return the SQLMeshMultiAssetOptions"""
+        output = SQLMeshMultiAssetOptions()
+        cache_writer.start_cache()
+
+        for entry in streamer.stream_assets():
+            payload = entry.payload
+            match payload:
+                case CachedAssetOut():
+                    asset_out = payload.to_asset_out()
+                    output.outs[payload.model_key] = asset_out
+                case CachedInternalAssetDeps():
+                    output.internal_asset_deps = payload.to_internal_asset_deps()
+                case CachedDeps():
+                    output.deps = payload.to_deps()
+                case CachedMetadata():
+                    continue
+            cache_writer.append_to_cache(entry)
+        return output
+
+    def to_asset_outs(
+        self,
+        environment: str,
+        translator: SQLMeshDagsterTranslator,
+        cache_options: DagsterSQLMeshCacheOptions | None = None,
+    ) -> SQLMeshMultiAssetOptions:
+        """Loads all the asset outs of the current sqlmesh environment. If a
+        cache is provided, it will be tried first to load the asset outs."""
+
+        cache_options = cache_options or DagsterSQLMeshCacheOptions(
+            enabled=False,
+        )
+
+        cache_writer: CacheableAssetCacheWriter = DummyCacheableAssetWriter()
+        if cache_options.enabled:
+            cache_streamer = cache_options.asset_streamer(environment)
+
+            if cache_streamer.is_valid:
+                logger.info(
+                    f"Using cache for environment {environment} at {cache_streamer.cache_path}"
+                )
+                return self.to_asset_outs_from_streamer(cache_streamer, cache_writer)
+            else:
+                logger.info(
+                    f"Cache for environment {environment} is invalid or does not exist. Rebuilding assets."
+                )
+                # Set the cache writer to be the cache_streamer as opposed to
+                # the dummy so it can write to the cache
+                cache_writer = cache_streamer
+        
         with self.instance(environment, "to_asset_outs") as instance:
-            context = instance.context
-            output = SQLMeshMultiAssetOptions()
-            depsMap: dict[str, CoercibleToAssetDep] = {}
-
-            for model, deps in instance.non_external_models_dag():
-                asset_key = translator.get_asset_key(context=context, fqn=model.fqn)
-                model_deps = [
-                    SQLMeshModelDep(fqn=dep, model=context.get_model(dep))
-                    for dep in deps
-                ]
-                internal_asset_deps: set[AssetKey] = set()
-                asset_tags = translator.get_tags(context, model)
-
-                for dep in model_deps:
-                    if dep.model:
-                        internal_asset_deps.add(
-                            translator.get_asset_key(context, dep.model.fqn)
-                        )
-                    else:
-                        table = get_asset_key_str(dep.fqn)
-                        key = translator.get_asset_key(context, dep.fqn)
-                        internal_asset_deps.add(key)
-                        # create an external dep
-                        depsMap[table] = AssetDep(key)
-                model_key = get_asset_key_str(model.fqn)
-                # If current Dagster supports "kinds", add labels for Dagster UI
-                if "kinds" in signature(AssetOut).parameters:
-                    output.outs[model_key] = AssetOut(
-                        key=asset_key, tags=asset_tags, is_required=False,
-                        group_name=translator.get_group_name(context, model),
-                        kinds={"sqlmesh", translator._get_context_dialect(context).lower()}
-                    )
-                else:
-                    output.outs[model_key] = AssetOut(
-                        key=asset_key, tags=asset_tags, is_required=False,
-                        group_name=translator.get_group_name(context, model)
-                    )
-                output.internal_asset_deps[model_key] = internal_asset_deps
-
-            output.deps = list(depsMap.values())
-            return output
+            # If no valid cache, use the SQLMesh instance to stream assets 
+            cache_streamer = SQLMeshInstanceAssetStreamer(instance=instance, translator=translator)
+            return self.to_asset_outs_from_streamer(cache_streamer, cache_writer)

--- a/dagster_sqlmesh/controller/dagster.py
+++ b/dagster_sqlmesh/controller/dagster.py
@@ -1,24 +1,13 @@
 # pyright: reportPrivateImportUsage=false
 import logging
-import time
-import typing as t
-from dataclasses import dataclass
-from inspect import signature
-from pathlib import Path
-
-from dagster import AssetDep, AssetKey, AssetOut
-from dagster._core.definitions.asset_dep import CoercibleToAssetDep
-from pydantic import BaseModel, Field, model_validator
 
 from dagster_sqlmesh.controller.base import (
     ContextCls,
     SQLMeshController,
-    SQLMeshInstance,
 )
 from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
 from dagster_sqlmesh.types import (
     ConvertibleToAssetDep,
-    ConvertibleToAssetKey,
     ConvertibleToAssetOut,
     SQLMeshModelDep,
     SQLMeshMultiAssetOptions,
@@ -26,300 +15,6 @@ from dagster_sqlmesh.types import (
 from dagster_sqlmesh.utils import get_asset_key_str
 
 logger = logging.getLogger(__name__)
-
-
-class CachedMetadata(BaseModel):
-    """Metadata for the cache file"""
-
-    type: t.Literal["metadata"] = "metadata"
-
-    creation_ts: int
-    environment: str
-
-
-class CachedAssetOut(BaseModel):
-    type: t.Literal["asset_out"] = "asset_out"
-
-    model_key: str
-    asset_key: str
-    tags: t.Mapping[str, str]
-    is_required: bool
-    group_name: str
-    kinds: set[str] | None
-
-    def to_asset_out(self) -> AssetOut:
-        """Convert to a Dagster AssetOut object"""
-        if "kinds" in signature(AssetOut).parameters:
-            return AssetOut(
-                key=AssetKey.from_user_string(self.asset_key),
-                tags=self.tags,
-                is_required=self.is_required,
-                group_name=self.group_name,
-                kinds=self.kinds,
-            )
-        return AssetOut(
-            key=AssetKey.from_user_string(self.asset_key),
-            tags=self.tags,
-            is_required=self.is_required,
-            group_name=self.group_name,
-        )
-
-    @classmethod
-    def from_asset_out(cls, model_key: str, asset_out: AssetOut) -> "CachedAssetOut":
-        """Create from a Dagster AssetOut object"""
-        assert asset_out.key is not None, "AssetOut key must not be None"
-
-        return cls(
-            model_key=model_key,
-            asset_key=asset_out.key.to_user_string(),
-            tags=asset_out.tags or {},
-            is_required=asset_out.is_required,
-            group_name=asset_out.group_name or "",
-            kinds=asset_out.kinds,
-        )
-
-
-class CachedInternalAssetDeps(BaseModel):
-    type: t.Literal["internal_asset_dep"] = "internal_asset_dep"
-
-    internal_asset_deps: dict[str, set[str]]
-
-    def to_internal_asset_deps(self) -> dict[str, set[AssetKey]]:
-        """Convert to a Dagster internal asset dependencies dictionary"""
-        return {
-            k: {AssetKey.from_user_string(dep) for dep in v}
-            for k, v in self.internal_asset_deps.items()
-        }
-
-    @classmethod
-    def from_internal_asset_deps(
-        cls, internal_asset_deps: dict[str, set[AssetKey]]
-    ) -> "CachedInternalAssetDeps":
-        """Create from a Dagster internal asset dependencies dictionary"""
-        return cls(
-            internal_asset_deps={
-                k: {dep.to_user_string() for dep in v}
-                for k, v in internal_asset_deps.items()
-            }
-        )
-
-
-class CachedDeps(BaseModel):
-    type: t.Literal["deps"] = "deps"
-
-    deps: list[dict[str, str]]
-
-    def to_deps(self) -> list[CoercibleToAssetDep]:
-        """Convert to a Dagster deps list"""
-        return [AssetDep(AssetKey.from_user_string(dep["key"])) for dep in self.deps]
-
-    @classmethod
-    def from_deps(cls, deps: list[AssetDep]) -> "CachedDeps":
-        """Create from a Dagster deps list"""
-        return cls(deps=[{"key": dep.asset_key.to_user_string()} for dep in deps])
-
-
-CacheEntryPayload = (
-    CachedAssetOut | CachedInternalAssetDeps | CachedDeps | CachedMetadata
-)
-
-
-class CacheEntry(BaseModel):
-    payload: CacheEntryPayload = Field(discriminator="type")
-
-
-class DagsterSQLMeshCacheOptions(BaseModel):
-    """SQLMesh context cache for Dagster"""
-
-    enabled: bool
-    cache_dir: str = ""
-    cache_filename: str = "dagster_sqlmesh_cache.jsonl"
-    enable_ttl: bool = True
-    ttl_seconds: int = 60 * 5  # Defaults to 5 minutes
-
-    @model_validator(mode="after")
-    def validate_cache_dir(self):
-        """Ensure the cache directory is set if caching is enabled"""
-        if not self.enabled:
-            return self
-
-        if not self.cache_dir:
-            raise ValueError("cache_dir must be set")
-        return self
-
-    def cache_path(self, environment: str) -> str:
-        """Returns the full path to the cache file"""
-        return f"{self.cache_env_dir(environment)}/{self.cache_filename}"
-
-    def cache_env_dir(self, environment: str) -> str:
-        """Returns the directory for the cache file"""
-        return f"{self.cache_dir}/{environment}"
-
-    def asset_streamer(self, environment: str) -> "DagsterSQLMeshCache":
-        """Returns a cache streamer for the given environment"""
-        return DagsterSQLMeshCache(environment=environment, options=self)
-
-
-class CacheableAssetStreamer(t.Protocol):
-    """Protocol for streaming SQLMesh assets from a cache"""
-
-    def stream_assets(self) -> t.Iterator[CacheEntry]:
-        """Stream the cache file if it exists and is valid"""
-        ...
-
-
-class CacheableAssetCacheWriter(t.Protocol):
-    """Protocol for consuming SQLMesh assets from a cache"""
-
-    def append_to_cache(self, data: CacheEntry) -> None:
-        """Write data to the cache file"""
-        ...
-
-    def start_cache(self) -> None:
-        """Clear the cache to prepare for writing"""
-        ...
-
-
-class DummyCacheableAssetWriter(CacheableAssetCacheWriter):
-    """A dummy cache writer that does nothing"""
-
-    def append_to_cache(self, data: CacheEntry) -> None:
-        """Does nothing"""
-        pass
-
-    def start_cache(self) -> None:
-        """Does nothing"""
-        pass
-
-
-@dataclass(kw_only=True)
-class DagsterSQLMeshCache:
-    environment: str
-    options: DagsterSQLMeshCacheOptions
-
-    @property
-    def is_valid(self) -> bool:
-        """Check if the cache file is valid based on the TTL"""
-        try:
-            iterator = self.stream_assets()
-            metadata = next(iterator)  # Get the first entry which should be metadata
-            assert isinstance(
-                metadata.payload, CachedMetadata
-            ), "First entry must be CachedMetadata"
-            if not self.options.enable_ttl:
-                return True
-            if metadata.payload.creation_ts + self.options.ttl_seconds < int(
-                time.time()
-            ):
-                return False
-        except FileNotFoundError:
-            return False
-        except Exception as e:
-            logger.error(f"Error reading cache file: {e}")
-            return False
-        return False
-
-    @property
-    def cache_path(self) -> str:
-        """Returns the cache file path"""
-        return self.options.cache_path(self.environment)
-
-    def stream_assets(self) -> t.Iterator[CacheEntry]:
-        """Stream the cache file if it exists and is valid"""
-        try:
-            with open(self.cache_path) as f:
-                for line in f:
-                    entry = CacheEntry.model_validate_json(line)
-                    yield entry
-        except FileNotFoundError:
-            logger.warning(f"Cache file {self.cache_path} not found.")
-        except Exception as e:
-            logger.error(f"Error reading cache file {self.cache_path}: {e}")
-
-    def start_cache(self) -> None:
-        """Clear the cache to prepare for writing"""
-        # Ensure the cache directory exists
-        Path(self.options.cache_env_dir(self.environment)).mkdir(
-            parents=True, exist_ok=True
-        )
-        # Clear the cache file and write the initial metadata
-        metadata = CachedMetadata(
-            creation_ts=int(time.time()),
-            environment=self.environment,
-        )
-        entry = CacheEntry(payload=metadata)
-        with open(self.cache_path, "w") as f:
-            f.write(entry.model_dump_json())
-            f.write("\n")
-
-    def append_to_cache(self, data: CacheEntry) -> None:
-        """Append data to the cache file"""
-
-        with open(self.cache_path, "a") as f:
-            f.write(data.model_dump_json())
-            f.write("\n")
-
-
-@dataclass(kw_only=True)
-class SQLMeshInstanceAssetStreamer:
-    instance: SQLMeshInstance
-    translator: SQLMeshDagsterTranslator
-
-    def stream_assets(self) -> t.Iterator[CacheEntry]:
-        """Stream the assets from the SQLMesh instance"""
-        instance = self.instance
-        translator = self.translator
-
-        context = self.instance.context
-        internal_asset_deps_map: dict[str, set[AssetKey]] = {}
-        deps_map: dict[str, AssetDep] = {}
-
-        for model, deps in instance.non_external_models_dag():
-            asset_key = translator.get_asset_key(context=context, fqn=model.fqn)
-            model_deps = [
-                SQLMeshModelDep(fqn=dep, model=context.get_model(dep)) for dep in deps
-            ]
-            internal_asset_deps: set[AssetKey] = set()
-            asset_tags = translator.get_tags(context, model)
-
-            for dep in model_deps:
-                if dep.model:
-                    internal_asset_deps.add(
-                        translator.get_asset_key(context, dep.model.fqn)
-                    )
-                else:
-                    table = get_asset_key_str(dep.fqn)
-                    key = translator.get_asset_key(context, dep.fqn)
-                    internal_asset_deps.add(key)
-                    # create an external dep
-                    deps_map[table] = AssetDep(key)
-            model_key = get_asset_key_str(model.fqn)
-            # If current Dagster supports "kinds", add labels for Dagster UI
-            if "kinds" in signature(AssetOut).parameters:
-                yield CacheEntry(
-                    payload=CachedAssetOut(
-                        model_key=model_key,
-                        asset_key=asset_key.to_user_string(),
-                        tags=asset_tags,
-                        is_required=False,
-                        group_name=translator.get_group_name(context, model),
-                        kinds={
-                            "sqlmesh",
-                            translator.get_context_dialect(context).lower(),
-                        },
-                    )
-                )
-            internal_asset_deps_map[model_key] = internal_asset_deps
-
-        yield CacheEntry(
-            payload=CachedInternalAssetDeps.from_internal_asset_deps(
-                internal_asset_deps=internal_asset_deps_map
-            )
-        )
-
-        deps = list(deps_map.values())
-
-        yield CacheEntry(payload=CachedDeps.from_deps(deps=deps))
 
 
 class DagsterSQLMeshController(SQLMeshController[ContextCls]):
@@ -333,7 +28,7 @@ class DagsterSQLMeshController(SQLMeshController[ContextCls]):
         """Loads all the asset outs of the current sqlmesh environment. If a
         cache is provided, it will be tried first to load the asset outs."""
 
-        internal_asset_deps_map: dict[str, set[ConvertibleToAssetKey]] = {}
+        internal_asset_deps_map: dict[str, set[str]] = {}
         deps_map: dict[str, ConvertibleToAssetDep] = {}
         asset_outs: dict[str, ConvertibleToAssetOut] = {}
 
@@ -347,7 +42,7 @@ class DagsterSQLMeshController(SQLMeshController[ContextCls]):
                     SQLMeshModelDep(fqn=dep, model=context.get_model(dep))
                     for dep in deps
                 ]
-                internal_asset_deps: set[ConvertibleToAssetKey] = set()
+                internal_asset_deps: set[str] = set()
                 asset_tags = translator.get_tags(context, model)
 
                 for dep in model_deps:
@@ -356,15 +51,13 @@ class DagsterSQLMeshController(SQLMeshController[ContextCls]):
                             context, dep.model.fqn
                         ).to_user_string()
 
-                        internal_asset_deps.add(
-                            translator.create_asset_key(key=dep_asset_key_str)
-                        )
+                        internal_asset_deps.add(dep_asset_key_str)
                     else:
                         table = get_asset_key_str(dep.fqn)
                         key = translator.get_asset_key(
                             context, dep.fqn
                         ).to_user_string()
-                        internal_asset_deps.add(translator.create_asset_key(key=key))
+                        internal_asset_deps.add(key)
 
                         # create an external dep
                         deps_map[table] = translator.create_asset_dep(key=key)

--- a/dagster_sqlmesh/translator.py
+++ b/dagster_sqlmesh/translator.py
@@ -1,9 +1,46 @@
+import typing as t
 from collections.abc import Sequence
+from inspect import signature
 
-from dagster import AssetKey
+from dagster import AssetDep, AssetKey, AssetOut
 from sqlglot import exp
 from sqlmesh.core.context import Context
 from sqlmesh.core.model import Model
+
+from .types import ConvertibleToAssetDep, ConvertibleToAssetKey, ConvertibleToAssetOut
+
+
+class _IntermediateAssetOut:
+    def __init__(self, *, model_key: str, asset_key: str, **kwargs: t.Any):
+        self.model_key = model_key
+        self.asset_key = asset_key
+        self.kwargs = kwargs
+
+    def to_asset_out(self) -> AssetOut:
+        kwargs = self.kwargs.copy()
+
+        asset_key = AssetKey.from_user_string(self.asset_key)
+
+        if "kinds" not in signature(AssetOut).parameters:
+            kwargs.pop("kinds", None)
+
+        return AssetOut(asset_key=asset_key, **self.kwargs)
+
+
+class _IntermediateAssetDep:
+    def __init__(self, *, key: str):
+        self.key = key
+
+    def to_asset_dep(self) -> AssetDep:
+        return AssetDep(AssetKey.from_user_string(self.key))
+
+
+class _IntermediateAssetKey:
+    def __init__(self, *, key: str):
+        self.key = key
+
+    def to_asset_key(self) -> AssetKey:
+        return AssetKey.from_user_string(self.key)
 
 
 class SQLMeshDagsterTranslator:
@@ -19,13 +56,39 @@ class SQLMeshDagsterTranslator:
         asset_key_name = [table.catalog, table.db, table.name]
 
         return asset_key_name
-    
+
     def get_group_name(self, context: Context, model: Model) -> str:
         path = self.get_asset_key_name(model.fqn)
         return path[-2]
 
-    def _get_context_dialect(self, context: Context) -> str:
+    def get_context_dialect(self, context: Context) -> str:
         return context.engine_adapter.dialect
+
+    def create_asset_dep(self, *, key: str, **kwargs: t.Any) -> ConvertibleToAssetDep:
+        """Create an object that resolves to an AssetDep
+
+        Most users of this library will not need to use this method, it is
+        primarily the way we enable cacheable assets from dagster-sqlmesh.
+        """
+        return _IntermediateAssetDep(key=key, **kwargs)
+
+    def create_asset_out(
+        self, *, model_key: str, asset_key: str, **kwargs: t.Any
+    ) -> ConvertibleToAssetOut:
+        """Create an object that resolves to an AssetOut
+
+        Most users of this library will not need to use this method, it is
+        primarily the way we enable cacheable assets from dagster-sqlmesh.
+        """
+        return _IntermediateAssetOut(model_key=model_key, asset_key=asset_key, **kwargs)
+
+    def create_asset_key(self, **kwargs: t.Any) -> ConvertibleToAssetKey:
+        """Create an object that resolves to an AssetKey
+
+        Most users of this library will not need to use this method, it is
+        primarily the way we enable cacheable assets from dagster-sqlmesh.
+        """
+        return _IntermediateAssetKey(**kwargs)
 
     def get_tags(self, context: Context, model: Model) -> dict[str, str]:
         """Given the sqlmesh context and a model return the tags for that model"""

--- a/dagster_sqlmesh/types.py
+++ b/dagster_sqlmesh/types.py
@@ -1,8 +1,7 @@
 import typing as t
 from dataclasses import dataclass, field
 
-from dagster import AssetCheckResult, AssetKey, AssetMaterialization, AssetOut
-from dagster._core.definitions.asset_dep import CoercibleToAssetDep
+from dagster import AssetCheckResult, AssetDep, AssetKey, AssetMaterialization, AssetOut
 from sqlmesh.core.model import Model
 
 MultiAssetResponse = t.Iterable[AssetCheckResult | AssetMaterialization]
@@ -30,10 +29,44 @@ class SQLMeshModelDep:
 
     def parse_fqn(self) -> SQLMeshParsedFQN:
         return SQLMeshParsedFQN.parse(self.fqn)
+    
+class ConvertibleToAssetOut(t.Protocol):
+    def to_asset_out(self) -> AssetOut:
+        """Convert to an AssetOut object."""
+        ...
 
+class ConvertibleToAssetDep(t.Protocol):
+    def to_asset_dep(self) -> AssetDep:
+        """Convert to an AssetDep object."""
+        ...
+
+class ConvertibleToAssetKey(t.Protocol):
+    def to_asset_key(self) -> AssetKey:
+        ...
 
 @dataclass(kw_only=True)
 class SQLMeshMultiAssetOptions:
-    outs: dict[str, AssetOut] = field(default_factory=lambda: {})
-    deps: t.Iterable[CoercibleToAssetDep] = field(default_factory=lambda: {})
-    internal_asset_deps: dict[str, set[AssetKey]] = field(default_factory=lambda: {})
+    """Generic class for returning dagster multi asset options from SQLMesh, the
+    types used are intentionally generic so to allow for potentially using an
+    intermediate representation of the dagster asset objects. This is most
+    useful in caching purposes and is done to allow for users of this library to
+    manipulate the dagster asset creation process as they see fit."""
+
+    outs: dict[str, ConvertibleToAssetOut] = field(default_factory=lambda: {})
+    deps: t.Iterable[ConvertibleToAssetDep] = field(default_factory=lambda: {})
+    internal_asset_deps: dict[str, set[ConvertibleToAssetKey]] = field(default_factory=lambda: {})
+
+    def to_asset_outs(self) -> t.Mapping[str, AssetOut]:
+        """Convert to an iterable of AssetOut objects."""
+        return {key: out.to_asset_out() for key, out in self.outs.items()}
+
+    def to_asset_deps(self) -> t.Iterable[AssetDep]:
+        """Convert to an iterable of AssetDep objects."""
+        return [dep.to_asset_dep() for dep in self.deps]
+    
+    def to_internal_asset_deps(self) -> dict[str, set[AssetKey]]:
+        """Convert to a dictionary of internal asset dependencies."""
+        return {
+            key: {dep.to_asset_key() for dep in deps}
+            for key, deps in self.internal_asset_deps.items()
+        }

--- a/dagster_sqlmesh/types.py
+++ b/dagster_sqlmesh/types.py
@@ -52,9 +52,9 @@ class SQLMeshMultiAssetOptions:
     useful in caching purposes and is done to allow for users of this library to
     manipulate the dagster asset creation process as they see fit."""
 
-    outs: dict[str, ConvertibleToAssetOut] = field(default_factory=lambda: {})
-    deps: t.Iterable[ConvertibleToAssetDep] = field(default_factory=lambda: {})
-    internal_asset_deps: dict[str, set[ConvertibleToAssetKey]] = field(default_factory=lambda: {})
+    outs: t.Mapping[str, ConvertibleToAssetOut] = field(default_factory=lambda: {})
+    deps: t.Iterable[ConvertibleToAssetDep] = field(default_factory=lambda: [])
+    internal_asset_deps: t.Mapping[str, set[str]] = field(default_factory=lambda: {})
 
     def to_asset_outs(self) -> t.Mapping[str, AssetOut]:
         """Convert to an iterable of AssetOut objects."""
@@ -67,6 +67,6 @@ class SQLMeshMultiAssetOptions:
     def to_internal_asset_deps(self) -> dict[str, set[AssetKey]]:
         """Convert to a dictionary of internal asset dependencies."""
         return {
-            key: {dep.to_asset_key() for dep in deps}
+            key: {AssetKey.from_user_string(dep) for dep in deps}
             for key, deps in self.internal_asset_deps.items()
         }

--- a/sample/dagster_project/definitions.py
+++ b/sample/dagster_project/definitions.py
@@ -5,23 +5,51 @@ import typing as t
 import polars as pl
 from dagster import (
     AssetExecutionContext,
+    AssetKey,
     Definitions,
     MaterializeResult,
     asset,
     define_asset_job,
 )
 from dagster_duckdb_polars import DuckDBPolarsIOManager
+from sqlglot import exp
 
-from dagster_sqlmesh import SQLMeshContextConfig, SQLMeshResource, sqlmesh_assets
+from dagster_sqlmesh import (
+    Context,
+    SQLMeshContextConfig,
+    SQLMeshDagsterTranslator,
+    SQLMeshResource,
+    sqlmesh_assets,
+)
+from dagster_sqlmesh.controller import DagsterSQLMeshCacheOptions
 
 CURR_DIR = os.path.dirname(__file__)
 SQLMESH_PROJECT_PATH = os.path.abspath(os.path.join(CURR_DIR, "../sqlmesh_project"))
+SQLMESH_CACHE_PATH = os.path.join(SQLMESH_PROJECT_PATH, ".cache")
 DUCKDB_PATH = os.path.join(CURR_DIR, "../../db.db")
 
 sqlmesh_config = SQLMeshContextConfig(path=SQLMESH_PROJECT_PATH, gateway="local")
 
 
-@asset(key=["db", "sources", "reset_asset"])
+class RewrittenSQLMeshTranslator(SQLMeshDagsterTranslator):
+    """A contrived SQLMeshDagsterTranslator that flattens the catalog of the
+    sqlmesh project and only uses the table db and name
+
+    We include this as a test of the translator functionality.
+    """
+
+    def get_asset_key(self, context: Context, fqn: str) -> AssetKey:
+        table = exp.to_table(fqn)  # Ensure fqn is a valid table expression
+        if table.db == "sqlmesh_example":
+            # For the sqlmesh_example project, we use a custom key
+            return AssetKey(["sqlmesh", table.name])
+        return AssetKey([table.db, table.name])
+
+    def get_group_name(self, context, model):
+        return "sqlmesh"
+
+
+@asset(key=["sources", "reset_asset"])
 def reset_asset() -> MaterializeResult:
     """An asset used for testing this entire workflow. If the duckdb database is
     found, this will delete it. This allows us to continously test this dag if
@@ -34,7 +62,7 @@ def reset_asset() -> MaterializeResult:
     return MaterializeResult(metadata={"deleted": deleted})
 
 
-@asset(deps=[reset_asset], key=["db", "sources", "test_source"])
+@asset(deps=[reset_asset], key=["sources", "test_source"])
 def test_source() -> pl.DataFrame:
     """Sets up the `test_source` table in duckdb that one of the sample sqlmesh
     models depends on"""
@@ -52,15 +80,43 @@ def test_source() -> pl.DataFrame:
     )
 
 
-@sqlmesh_assets(environment="dev", config=sqlmesh_config, enabled_subsetting=True)
-def sqlmesh_project(context: AssetExecutionContext, sqlmesh: SQLMeshResource) -> t.Iterator[MaterializeResult]:
+@asset(deps=[AssetKey(["sqlmesh", "full_model"])])
+def post_full_model() -> pl.DataFrame:
+    """An asset that depends on the `full_model` asset from the sqlmesh project.
+    This is used to test that the sqlmesh assets are correctly materialized and
+    can be used in other assets.
+    """
+    import duckdb
+
+    conn = duckdb.connect(DUCKDB_PATH)
+    df = conn.query(
+        """
+        SELECT * FROM sqlmesh_example__dev.full_model
+    """
+    ).to_df()
+    conn.close()
+    return pl.from_dataframe(df)
+
+
+@sqlmesh_assets(
+    environment="dev",
+    config=sqlmesh_config,
+    enabled_subsetting=True,
+    dagster_sqlmesh_translator=RewrittenSQLMeshTranslator(),
+    cache_options=DagsterSQLMeshCacheOptions(
+        enabled=True, cache_dir=SQLMESH_CACHE_PATH
+    ),
+)
+def sqlmesh_project(
+    context: AssetExecutionContext, sqlmesh: SQLMeshResource
+) -> t.Iterator[MaterializeResult]:
     yield from sqlmesh.run(context)
 
 
 all_assets_job = define_asset_job(name="all_assets_job")
 
 defs = Definitions(
-    assets=[sqlmesh_project, test_source, reset_asset],
+    assets=[sqlmesh_project, test_source, reset_asset, post_full_model],
     resources={
         "sqlmesh": SQLMeshResource(config=sqlmesh_config),
         "io_manager": DuckDBPolarsIOManager(

--- a/sample/dagster_project/definitions.py
+++ b/sample/dagster_project/definitions.py
@@ -21,7 +21,6 @@ from dagster_sqlmesh import (
     SQLMeshResource,
     sqlmesh_assets,
 )
-from dagster_sqlmesh.controller import DagsterSQLMeshCacheOptions
 
 CURR_DIR = os.path.dirname(__file__)
 SQLMESH_PROJECT_PATH = os.path.abspath(os.path.join(CURR_DIR, "../sqlmesh_project"))
@@ -103,9 +102,6 @@ def post_full_model() -> pl.DataFrame:
     config=sqlmesh_config,
     enabled_subsetting=True,
     dagster_sqlmesh_translator=RewrittenSQLMeshTranslator(),
-    cache_options=DagsterSQLMeshCacheOptions(
-        enabled=True, cache_dir=SQLMESH_CACHE_PATH
-    ),
 )
 def sqlmesh_project(
     context: AssetExecutionContext, sqlmesh: SQLMeshResource

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "dagster-sqlmesh"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
This is a feature that the OSO team has discovered is something we very much need. We _might_ change where this caching takes place in the future if no external party wants to use this feature. 

For context, we have a very large SQLMesh project that actually has some models generated through "model factories". The project ends up generating something like 800 models and loading that on a fairly quick machine (AMD Ryzen 9 class + 64GB) ends up taking about 40 seconds. We also need to do some work on our side to likely cache the model generation (to speed up sqlmesh load times in general) but this ended up being an easier touch point. This caching enabled the load time to go from 40 seconds to 5 milliseconds. 