### PR TITLE
feat: change from ConvertibleToAssetDep to ConvertibleToAssetKey

### DIFF
--- a/dagster_sqlmesh/types.py
+++ b/dagster_sqlmesh/types.py
@@ -1,10 +1,11 @@
 import typing as t
 from dataclasses import dataclass, field
 
-from dagster import AssetCheckResult, AssetDep, AssetKey, AssetMaterialization, AssetOut
+from dagster import (
+    AssetKey,
+    AssetOut,
+)
 from sqlmesh.core.model import Model
-
-MultiAssetResponse = t.Iterable[AssetCheckResult | AssetMaterialization]
 
 
 @dataclass(kw_only=True)
@@ -30,39 +31,39 @@ class SQLMeshModelDep:
     def parse_fqn(self) -> SQLMeshParsedFQN:
         return SQLMeshParsedFQN.parse(self.fqn)
     
+
 class ConvertibleToAssetOut(t.Protocol):
     def to_asset_out(self) -> AssetOut:
         """Convert to an AssetOut object."""
         ...
 
-class ConvertibleToAssetDep(t.Protocol):
-    def to_asset_dep(self) -> AssetDep:
-        """Convert to an AssetDep object."""
-        ...
 
 class ConvertibleToAssetKey(t.Protocol):
+    """Protocol for objects that can be lazily converted to AssetKey."""
+
     def to_asset_key(self) -> AssetKey:
+        """Convert to an AssetKey object."""
         ...
+
 
 @dataclass(kw_only=True)
 class SQLMeshMultiAssetOptions:
-    """Generic class for returning dagster multi asset options from SQLMesh, the
-    types used are intentionally generic so to allow for potentially using an
-    intermediate representation of the dagster asset objects. This is most
-    useful in caching purposes and is done to allow for users of this library to
-    manipulate the dagster asset creation process as they see fit."""
+    """Intermediate representation of Dagster multi-asset options from SQLMesh.
+
+    Uses generic types to allow caching and lazy evaluation during asset loading.
+    """
 
     outs: t.Mapping[str, ConvertibleToAssetOut] = field(default_factory=lambda: {})
-    deps: t.Iterable[ConvertibleToAssetDep] = field(default_factory=lambda: [])
+    deps: t.Iterable[ConvertibleToAssetKey] = field(default_factory=lambda: [])
     internal_asset_deps: t.Mapping[str, set[str]] = field(default_factory=lambda: {})
 
     def to_asset_outs(self) -> t.Mapping[str, AssetOut]:
         """Convert to an iterable of AssetOut objects."""
         return {key: out.to_asset_out() for key, out in self.outs.items()}
 
-    def to_asset_deps(self) -> t.Iterable[AssetDep]:
-        """Convert to an iterable of AssetDep objects."""
-        return [dep.to_asset_dep() for dep in self.deps]
+    def to_asset_deps(self) -> t.Iterable[AssetKey]:
+        """Convert dependencies to AssetKey objects."""
+        return [dep.to_asset_key() for dep in self.deps]
     
     def to_internal_asset_deps(self) -> dict[str, set[AssetKey]]:
         """Convert to a dictionary of internal asset dependencies."""

--- a/sample/dagster_project/definitions.py
+++ b/sample/dagster_project/definitions.py
@@ -32,7 +32,7 @@ class CustomSQLMeshContextConfig(SQLMeshContextConfig):
     custom_key: str
 
     def get_translator(self):
-        return RewrittenSQLMeshTranslator(self.custom_key)
+        return RewrittenSQLMeshTranslator(custom_key=self.custom_key)
 
 sqlmesh_config = CustomSQLMeshContextConfig(
     path=SQLMESH_PROJECT_PATH, 
@@ -45,10 +45,13 @@ class RewrittenSQLMeshTranslator(SQLMeshDagsterTranslator):
     sqlmesh project and only uses the table db and name
 
     We include this as a test of the translator functionality.
+    
+    Note: Since SQLMeshDagsterTranslator extends ConfigurableResource, custom
+    attributes must be declared as Pydantic fields (not set in __init__).
     """
 
-    def __init__(self, custom_key: str):
-        self.custom_key = custom_key
+    # Declare custom_key as a Pydantic field (ConfigurableResource is frozen)
+    custom_key: str
 
     def get_asset_key(self, context: Context, fqn: str) -> AssetKey:
         table = exp.to_table(fqn)  # Ensure fqn is a valid table expression


### PR DESCRIPTION
This would close #54.

- Convert SQLMeshDagsterTranslator to extend ConfigurableResource for Dagster resource injection pattern
- Change IntermediateAssetOut and IntermediateAssetDep from Pydantic BaseModel to dataclass for lighter weight
- Use AssetKey instead of AssetDep for external dependencies to prevent duplicate asset definitions in containerized code locations
- Remove translator attribute from SQLMeshResource; use config.get_translator() as single source of truth
- Simplify docstrings throughout