### PR TITLE
fix: sanitize hyphens in get_asset_key_str to prevent KeyError on hyphenated internal asset names

### DIFF
--- a/dagster_sqlmesh/test_translator.py
+++ b/dagster_sqlmesh/test_translator.py
@@ -4,5 +4,5 @@ from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
 def test_get_asset_key_str_sanitizes_hyphens():
     translator = SQLMeshDagsterTranslator()
     result = translator.get_asset_key_str("my-catalog.my-schema.my-model")
-    assert result == "sqlmesh__my_catalog_my_database_my_model"
+    assert result == "sqlmesh__my_catalog_my_schema_my_model"
     assert "-" not in result

--- a/dagster_sqlmesh/test_translator.py
+++ b/dagster_sqlmesh/test_translator.py
@@ -1,0 +1,8 @@
+from dagster_sqlmesh.translator import SQLMeshDagsterTranslator
+
+
+def test_get_asset_key_str_sanitizes_hyphens():
+    translator = SQLMeshDagsterTranslator()
+    result = translator.get_asset_key_str("my-catalog.my-schema.my-model")
+    assert result == "sqlmesh__my_catalog_my_database_my_model"
+    assert "-" not in result

--- a/dagster_sqlmesh/translator.py
+++ b/dagster_sqlmesh/translator.py
@@ -163,8 +163,8 @@ class SQLMeshDagsterTranslator:
         """
         table = exp.to_table(fqn)
         asset_key_name = [table.catalog, table.db, table.name]
-        
-        return "sqlmesh__" + "_".join(asset_key_name)
+
+        return ("sqlmesh__" + "_".join(asset_key_name)).replace("-", "_")
 
     def get_tags(self, context: Context, model: Model) -> dict[str, str]:
         """Get Dagster asset tags for a SQLMesh model.


### PR DESCRIPTION
Howdy! I encountered a crash when attempting to add a SQLMesh pipeline that used a GCP project with a hyphen as the gateway, error message copied below. Fixes #62.

Comments indicated that the function `get_asset_key_str()` in `translator.py:167` had been intended to normalize hyphens, but that the code to do so hadn't been added. The fix is one line and a test that target that function. The new test passes, but some other tests failed because of what looks like a preexisting bug with DuckDB on Windows. 

Before the fix, `@sqlmesh_assets` passed hyphenated `asset_outs` and `internal_asset_deps_map` dicts to Dagster. Dagster's `@multi_asset()` function would then hand off the names to `build_named_outs` which normalized only the asset output names. The `asset_deps` don't get normalized by `build_named_outs`, retain their hyphens, and then fail to reconcile on `decorator_assets_definition_builder.py:461`. Dagster validation on line 443 of the same file checks the pre-normalization names and thus returns no error. 

This is my first open source contribution! If you have any feedback on my code or anything else, please holler, I'm all ears! I considered whether there should maybe be a fix in Dagster too, but I don't know enough to say. I'd love to contribute there too if it's worth doing.

`Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\myusername\Documents\my_project\dagster_defs.py", line 18, in <module>
    @sqlmesh_assets(
     ^^^^^^^^^^^^^^^
  File "C:\Users\myusername\Documents\my_project\.venv\Lib\site-packages\dagster\_core\definitions\decorators\asset_decorator.py", line 744, in inner
    builder = DecoratorAssetsDefinitionBuilder.for_multi_asset(args=args, fn=fn)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\myusername\Documents\my_project\.venv\Lib\site-packages\dagster\_core\definitions\decorators\decorator_assets_definition_builder.py", line 328, in for_multi_asset
    return DecoratorAssetsDefinitionBuilder.from_asset_outs_in_asset_centric_decorator(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\myusername\Documents\my_project\.venv\Lib\site-packages\dagster\_core\definitions\decorators\decorator_assets_definition_builder.py", line 461, in from_asset_outs_in_asset_centric_decorator
    internal_deps = {keys_by_output_name[name]: asset_deps[name] for name in asset_deps}
                     ~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'sqlmesh__my-gcp-project_my_schema_example_model'`