### PR TITLE
fix: don't emit external models as multi-asset outputs (#65)

### DIFF
--- a/dagster_sqlmesh/controller/base.py
+++ b/dagster_sqlmesh/controller/base.py
@@ -367,7 +367,12 @@ class SQLMeshInstance(t.Generic[ContextCls]):
         for model_fqn, deps in dag.graph.items():
             logger.debug(f"model found: {model_fqn}")
             model = self.context.get_model(model_fqn)
-            if not model:
+            if not model or model.kind.is_external:
+                # External models are source tables the project READS, not models it
+                # materialises. They must never become multi-asset outputs (that produces
+                # a phantom asset and collides with any existing asset — e.g. a dlt asset —
+                # that already owns that key). They still surface as dependency edges via
+                # to_asset_outs' dep handling.
                 continue
             yield (model, deps)
 

--- a/dagster_sqlmesh/controller/dagster.py
+++ b/dagster_sqlmesh/controller/dagster.py
@@ -45,13 +45,19 @@ class DagsterSQLMeshController(SQLMeshController[ContextCls]):
                 asset_tags = translator.get_tags(context, model)
 
                 for dep in model_deps:
-                    if dep.model:
+                    if dep.model and not dep.model.kind.is_external:
                         dep_asset_key_str = translator.get_asset_key(
                             context, dep.model.fqn
                         ).to_user_string()
 
                         internal_asset_deps.add(dep_asset_key_str)
                     else:
+                        # A dependency that is NOT a materialised model of this project —
+                        # either an unmodelled table or an EXTERNAL model. Both are upstream
+                        # asset DEPS, not outputs. (External models resolve to a truthy
+                        # `dep.model`, so they must be routed here explicitly; otherwise they
+                        # would be added to internal_asset_deps without a matching out or dep,
+                        # which Dagster rejects once they are no longer emitted as outs.)
                         table = translator.get_asset_key_str(dep.fqn)
                         key = translator.get_asset_key(
                             context, dep.fqn


### PR DESCRIPTION
Fixes #65 (and the root cause behind #53).

## Problem

`SQLMeshController.non_external_models_dag()` doesn't actually filter external models. Its only guard is `if not model: continue`, which skips FQNs that resolve to *no* model — but an **external** model resolves to a real `Model` (`kind.is_external == True`), so it passes through, and `to_asset_outs()` builds an `AssetOut` for it. External models are source tables the project **reads**, so emitting them as **outputs** is wrong: it materializes phantom assets and collides with any existing asset that already owns that key (e.g. a `dlt` asset landing the same physical table) → `DagsterInvalidDefinitionError: Duplicate asset key`.

This is what #65 observed (correctly spotting `non_external_models_dag`) and the symptom #53 hit.

## Fix

Two small changes so externals become **dependency-only** edges:

1. **`controller/base.py`** — `non_external_models_dag()` now skips `model.kind.is_external` (living up to its name). Externals are no longer emitted as outs, and also drop out of the materializable-model set `resource.py` derives from it.
2. **`controller/dagster.py`** — `to_asset_outs()`'s dependency loop routes external-model deps down the asset-dep path. **This is required, not cosmetic:** an external dep resolves to a truthy `dep.model`, so with change (1) alone it would be added to `internal_asset_deps` without a matching out *or* dep, and Dagster rejects that (`... specified as asset inputs, but are not specified in internal_asset_deps`). Routing it through `create_asset_dep` keeps `deps` and `internal_asset_deps` consistent.

## Verification

Tested against a real project with **5 external models** (4 source tables + 1 cross-database dimension):

- **Before:** externals emitted as outs; a translator that remaps an external onto a key owned by another asset → `Duplicate asset key`.
- **After:** externals appear only in `deps`, never in `outs`; the multi-asset builds cleanly; the remapped-external case no longer collides.

**Backward compatible:** projects with no external models are unaffected — including this repo's `sample/sqlmesh_project`, so the existing `test_sqlmesh_context_to_asset_outs` assertions (`deps == 1`, `outs == 10`) are unchanged.

## Note on tests

The sample project currently has **no external model**, which is why this path wasn't caught. I'm happy to add a regression test, but it needs a fixture with an external model (either extending the sample — which would shift the counts in the existing test — or a dedicated fixture). Let me know which you'd prefer and I'll push it in this PR.